### PR TITLE
Add Proxy Submission Acceptance Tests

### DIFF
--- a/tests/baseCaseTests.js
+++ b/tests/baseCaseTests.js
@@ -1,32 +1,32 @@
 import { Selector } from 'testcafe';
-const commonTest = require("./commonTest");
+import { userNih, currLocation, TIMEOUT_LENGTH } from './commonTest';
 
 fixture `Acceptance Testing`
     .page`https://pass.local`;
 
 test('can walk through an nih submission workflow and make a submission - base case', async t => {
     // Log in
-    await t.useRole(commonTest.userNih);
+    await t.useRole(userNih);
 
     // Go to Submissions
     const submissionsButton = Selector('.nav-link.ember-view').withExactText('Submissions');
     await t.expect(submissionsButton.exists).ok();
     await t.click(submissionsButton);
 
-    await t.expect(commonTest.currLocation()).eql('https://pass.local/app/submissions');
+    await t.expect(currLocation()).eql('https://pass.local/app/submissions');
 
     // Start new Submission
     const startNewSubmissionButton = Selector('.ember-view.btn.btn-primary.btn-small.pull-right').withAttribute('href', '/app/submissions/new');
     await t.expect(startNewSubmissionButton.exists).ok();
     await t.click(startNewSubmissionButton);
 
-    await t.expect(commonTest.currLocation()).eql('https://pass.local/app/submissions/new/basics');
+    await t.expect(currLocation()).eql('https://pass.local/app/submissions/new/basics');
 
     // Input DOI
     const doiInput = Selector('#doi');
     await t.expect(doiInput().exists).ok();
     await t.typeText(doiInput, '10.1039/c7an01256j', { paste: true });
-    const toastMessage = Selector('.toast-message', {timeout: 15000}).withText("We've pre-populated information from the DOI provided!");
+    const toastMessage = Selector('.toast-message', {timeout: TIMEOUT_LENGTH}).withText("We've pre-populated information from the DOI provided!");
     await t.expect(toastMessage.exists).ok();
 
 
@@ -51,7 +51,7 @@ test('can walk through an nih submission workflow and make a submission - base c
     await t.expect(goToGrantsButton.exists).ok();
     await t.click(goToGrantsButton);
 
-    await t.expect(commonTest.currLocation()).eql('https://pass.local/app/submissions/new/grants');
+    await t.expect(currLocation()).eql('https://pass.local/app/submissions/new/grants');
 
     // Select a Grant
     const nihGrant = Selector('#grants-selection-table a').withText('QQDV123P7');
@@ -67,7 +67,7 @@ test('can walk through an nih submission workflow and make a submission - base c
     await t.expect(goToPoliciesButton.exists).ok();
     await t.click(goToPoliciesButton);
 
-    await t.expect(commonTest.currLocation()).eql('https://pass.local/app/submissions/new/policies');
+    await t.expect(currLocation()).eql('https://pass.local/app/submissions/new/policies');
 
     // Check selected Policy
     const currPolicy = Selector('input').withAttribute('data-test-workflow-policies-radio-no-direct-deposit');
@@ -78,7 +78,7 @@ test('can walk through an nih submission workflow and make a submission - base c
     await t.expect(goToRepositoriesButton.exists).ok();
     await t.click(goToRepositoriesButton);
 
-    await t.expect(commonTest.currLocation()).eql('https://pass.local/app/submissions/new/repositories');
+    await t.expect(currLocation()).eql('https://pass.local/app/submissions/new/repositories');
 
     // Check Required Repositories
     const requiredRepositories = Selector('ul')
@@ -96,7 +96,7 @@ test('can walk through an nih submission workflow and make a submission - base c
     await t.expect(goToMetadataButton.exists).ok();
     await t.click(goToMetadataButton);
 
-    await t.expect(commonTest.currLocation()).eql('https://pass.local/app/submissions/new/metadata');
+    await t.expect(currLocation()).eql('https://pass.local/app/submissions/new/metadata');
 
     // Check Article Title
     const articleTitle = Selector('textarea').withAttribute('name', 'title');
@@ -113,7 +113,7 @@ test('can walk through an nih submission workflow and make a submission - base c
     await t.expect(goToFilesButton.exists).ok();
     await t.click(goToFilesButton);
 
-    await t.expect(commonTest.currLocation()).eql('https://pass.local/app/submissions/new/files');
+    await t.expect(currLocation()).eql('https://pass.local/app/submissions/new/files');
 
     // Get Browse Files button
     const browseFilesButton = Selector('#file-multiple-input');
@@ -129,7 +129,7 @@ test('can walk through an nih submission workflow and make a submission - base c
     await t.expect(goToReviewButton.exists).ok();
     await t.click(goToReviewButton);
 
-    await t.expect(commonTest.currLocation()).eql('https://pass.local/app/submissions/new/review');
+    await t.expect(currLocation()).eql('https://pass.local/app/submissions/new/review');
 
     // Review Title
     const reviewTitle = Selector('.mb-1').withAttribute('data-test-workflow-review-title');
@@ -178,7 +178,7 @@ test('can walk through an nih submission workflow and make a submission - base c
     await t.expect(linkToSubmission.exists).ok();
     await t.click(linkToSubmission);
 
-    const submissionDetailsBody = Selector('h2', {timeout: 30000}).withExactText('Submission Detail');
+    const submissionDetailsBody = Selector('h2', {timeout: TIMEOUT_LENGTH}).withExactText('Submission Detail');
     await t.expect(submissionDetailsBody.exists).ok();
 
     // Submission heading
@@ -209,8 +209,4 @@ test('can walk through an nih submission workflow and make a submission - base c
     const submittedFile = Selector('a').withExactText('my-submission.pdf');
     await t.expect(submittedFile.exists).ok();
 
-}).timeouts({
-    pageLoadTimeout:    60000,
-    pageRequestTimeout: 60000,
-    ajaxRequestTimeout: 60000,
-});;
+}).disablePageCaching;

--- a/tests/baseCaseTests.js
+++ b/tests/baseCaseTests.js
@@ -1,59 +1,26 @@
-import { Selector, Role, ClientFunction } from 'testcafe';
-
-const userNih = Role('https://pass.local', async t =>{
-    await t
-        .click('#login-button')
-        .typeText(Selector('#username'), 'nih-user')
-        .typeText(Selector('#password'), 'moo')
-        .click(Selector(".form-element.form-button"));
-});
-
-const userIncompleteNih = Role('https://pass.local', async t =>{
-    await t
-        .click('#login-button')
-        .typeText(Selector('#username'), 'incomplete-nih-user')
-        .typeText(Selector('#password'), 'moo')
-        .click(Selector(".form-element.form-button"));
-});
-
-const userStaff1 = Role('https://pass.local', async t =>{
-    await t
-        .click('#login-button')
-        .typeText(Selector('#username'), 'staff1')
-        .typeText(Selector('#password'), 'moo')
-        .click(Selector(".form-element.form-button"));
-});
-
-const userAdminSubmitter = Role('https://pass.local', async t =>{
-    await t
-        .click('#login-button')
-        .typeText(Selector('#username'), 'admin-submitter')
-        .typeText(Selector('#password'), 'moo')
-        .click(Selector(".form-element.form-button"));
-});
-
-const currLocation = ClientFunction((() => window.location.href));
+import { Selector } from 'testcafe';
+const commonTest = require("./commonTest");
 
 fixture `Acceptance Testing`
     .page`https://pass.local`;
 
 test('can walk through an nih submission workflow and make a submission - base case', async t => {
     // Log in
-    await t.useRole(userNih);
+    await t.useRole(commonTest.userNih);
 
     // Go to Submissions
     const submissionsButton = Selector('.nav-link.ember-view').withExactText('Submissions');
     await t.expect(submissionsButton.exists).ok();
     await t.click(submissionsButton);
 
-    await t.expect(currLocation()).eql('https://pass.local/app/submissions');
+    await t.expect(commonTest.currLocation()).eql('https://pass.local/app/submissions');
 
     // Start new Submission
     const startNewSubmissionButton = Selector('.ember-view.btn.btn-primary.btn-small.pull-right').withAttribute('href', '/app/submissions/new');
     await t.expect(startNewSubmissionButton.exists).ok();
     await t.click(startNewSubmissionButton);
 
-    await t.expect(currLocation()).eql('https://pass.local/app/submissions/new/basics');
+    await t.expect(commonTest.currLocation()).eql('https://pass.local/app/submissions/new/basics');
 
     // Input DOI
     const doiInput = Selector('#doi');
@@ -84,7 +51,7 @@ test('can walk through an nih submission workflow and make a submission - base c
     await t.expect(goToGrantsButton.exists).ok();
     await t.click(goToGrantsButton);
 
-    await t.expect(currLocation()).eql('https://pass.local/app/submissions/new/grants');
+    await t.expect(commonTest.currLocation()).eql('https://pass.local/app/submissions/new/grants');
 
     // Select a Grant
     const nihGrant = Selector('#grants-selection-table a').withText('QQDV123P7');
@@ -100,7 +67,7 @@ test('can walk through an nih submission workflow and make a submission - base c
     await t.expect(goToPoliciesButton.exists).ok();
     await t.click(goToPoliciesButton);
 
-    await t.expect(currLocation()).eql('https://pass.local/app/submissions/new/policies');
+    await t.expect(commonTest.currLocation()).eql('https://pass.local/app/submissions/new/policies');
 
     // Check selected Policy
     const currPolicy = Selector('input').withAttribute('data-test-workflow-policies-radio-no-direct-deposit');
@@ -111,7 +78,7 @@ test('can walk through an nih submission workflow and make a submission - base c
     await t.expect(goToRepositoriesButton.exists).ok();
     await t.click(goToRepositoriesButton);
 
-    await t.expect(currLocation()).eql('https://pass.local/app/submissions/new/repositories');
+    await t.expect(commonTest.currLocation()).eql('https://pass.local/app/submissions/new/repositories');
 
     // Check Required Repositories
     const requiredRepositories = Selector('ul')
@@ -129,7 +96,7 @@ test('can walk through an nih submission workflow and make a submission - base c
     await t.expect(goToMetadataButton.exists).ok();
     await t.click(goToMetadataButton);
 
-    await t.expect(currLocation()).eql('https://pass.local/app/submissions/new/metadata');
+    await t.expect(commonTest.currLocation()).eql('https://pass.local/app/submissions/new/metadata');
 
     // Check Article Title
     const articleTitle = Selector('textarea').withAttribute('name', 'title');
@@ -146,7 +113,7 @@ test('can walk through an nih submission workflow and make a submission - base c
     await t.expect(goToFilesButton.exists).ok();
     await t.click(goToFilesButton);
 
-    await t.expect(currLocation()).eql('https://pass.local/app/submissions/new/files');
+    await t.expect(commonTest.currLocation()).eql('https://pass.local/app/submissions/new/files');
 
     // Get Browse Files button
     const browseFilesButton = Selector('#file-multiple-input');
@@ -162,7 +129,7 @@ test('can walk through an nih submission workflow and make a submission - base c
     await t.expect(goToReviewButton.exists).ok();
     await t.click(goToReviewButton);
 
-    await t.expect(currLocation()).eql('https://pass.local/app/submissions/new/review');
+    await t.expect(commonTest.currLocation()).eql('https://pass.local/app/submissions/new/review');
 
     // Review Title
     const reviewTitle = Selector('.mb-1').withAttribute('data-test-workflow-review-title');
@@ -211,7 +178,7 @@ test('can walk through an nih submission workflow and make a submission - base c
     await t.expect(linkToSubmission.exists).ok();
     await t.click(linkToSubmission);
 
-    const submissionDetailsBody = Selector('h2', {timeout: 15000}).withExactText('Submission Detail');
+    const submissionDetailsBody = Selector('h2', {timeout: 30000}).withExactText('Submission Detail');
     await t.expect(submissionDetailsBody.exists).ok();
 
     // Submission heading

--- a/tests/commonTest.js
+++ b/tests/commonTest.js
@@ -1,0 +1,43 @@
+import { Selector, Role, ClientFunction } from 'testcafe';
+
+const userNih = Role('https://pass.local', async t =>{
+    await t
+        .click('#login-button')
+        .typeText(Selector('#username'), 'nih-user')
+        .typeText(Selector('#password'), 'moo')
+        .click(Selector(".form-element.form-button"));
+});
+
+const userIncompleteNih = Role('https://pass.local', async t =>{
+    await t
+        .click('#login-button')
+        .typeText(Selector('#username'), 'incomplete-nih-user')
+        .typeText(Selector('#password'), 'moo')
+        .click(Selector(".form-element.form-button"));
+});
+
+const userStaff1 = Role('https://pass.local', async t =>{
+    await t
+        .click('#login-button')
+        .typeText(Selector('#username'), 'staff1')
+        .typeText(Selector('#password'), 'moo')
+        .click(Selector(".form-element.form-button"));
+});
+
+const userAdminSubmitter = Role('https://pass.local', async t =>{
+    await t
+        .click('#login-button')
+        .typeText(Selector('#username'), 'admin-submitter')
+        .typeText(Selector('#password'), 'moo')
+        .click(Selector(".form-element.form-button"));
+});
+
+const currLocation = ClientFunction((() => window.location.href));
+
+module.exports = {
+    userNih,
+    userIncompleteNih,
+    userStaff1,
+    userAdminSubmitter,
+    currLocation,
+};

--- a/tests/commonTest.js
+++ b/tests/commonTest.js
@@ -1,6 +1,6 @@
 import { Selector, Role, ClientFunction } from 'testcafe';
 
-const userNih = Role('https://pass.local', async t =>{
+export const userNih = Role('https://pass.local', async t =>{
     await t
         .click('#login-button')
         .typeText(Selector('#username'), 'nih-user')
@@ -8,7 +8,7 @@ const userNih = Role('https://pass.local', async t =>{
         .click(Selector(".form-element.form-button"));
 });
 
-const userIncompleteNih = Role('https://pass.local', async t =>{
+export const userIncompleteNih = Role('https://pass.local', async t =>{
     await t
         .click('#login-button')
         .typeText(Selector('#username'), 'incomplete-nih-user')
@@ -16,7 +16,7 @@ const userIncompleteNih = Role('https://pass.local', async t =>{
         .click(Selector(".form-element.form-button"));
 });
 
-const userStaff1 = Role('https://pass.local', async t =>{
+export const userStaff1 = Role('https://pass.local', async t =>{
     await t
         .click('#login-button')
         .typeText(Selector('#username'), 'staff1')
@@ -24,7 +24,7 @@ const userStaff1 = Role('https://pass.local', async t =>{
         .click(Selector(".form-element.form-button"));
 });
 
-const userAdminSubmitter = Role('https://pass.local', async t =>{
+export const userAdminSubmitter = Role('https://pass.local', async t =>{
     await t
         .click('#login-button')
         .typeText(Selector('#username'), 'admin-submitter')
@@ -32,12 +32,7 @@ const userAdminSubmitter = Role('https://pass.local', async t =>{
         .click(Selector(".form-element.form-button"));
 });
 
-const currLocation = ClientFunction((() => window.location.href));
+export const currLocation = ClientFunction((() => window.location.href));
 
-module.exports = {
-    userNih,
-    userIncompleteNih,
-    userStaff1,
-    userAdminSubmitter,
-    currLocation,
-};
+// set in milliseconds
+export const TIMEOUT_LENGTH = parseInt(process.env.TIMEOUT_LENGTH) || 60000;

--- a/tests/proxySubmissionTests.js
+++ b/tests/proxySubmissionTests.js
@@ -1,5 +1,5 @@
 import { Selector } from 'testcafe';
-const commonTest = require("./commonTest");
+import { userNih, currLocation, TIMEOUT_LENGTH } from './commonTest';
 
 fixture `Acceptance Testing`
     .page`https://pass.local`;
@@ -7,14 +7,14 @@ fixture `Acceptance Testing`
 test( 'can walk through a proxy submission workflow and make a submission - with pass account', async t => {
 
     // use role
-    await t.useRole(commonTest.userNih);
+    await t.useRole(userNih);
 
     // Go to Submissions
     const submissionsButton = Selector('.nav-link.ember-view').withExactText('Submissions');
     await t.expect(submissionsButton.exists).ok();
     await t.click(submissionsButton);
 
-    await t.expect(commonTest.currLocation()).eql('https://pass.local/app/submissions');
+    await t.expect(currLocation()).eql('https://pass.local/app/submissions');
 
     // Start new Submission
     const startNewSubmissionButton = Selector('.ember-view.btn.btn-primary.btn-small.pull-right').withAttribute('href', '/app/submissions/new');
@@ -22,7 +22,7 @@ test( 'can walk through a proxy submission workflow and make a submission - with
     await t.click(startNewSubmissionButton);
 
     // Select Proxy Submission button
-    await t.expect(commonTest.currLocation()).eql('https://pass.local/app/submissions/new/basics');
+    await t.expect(currLocation()).eql('https://pass.local/app/submissions/new/basics');
     const proxyRadioButton = Selector('input').withAttribute('data-test-proxy-radio-button');
     await t.expect(proxyRadioButton.exists).ok();
     await t.click(proxyRadioButton);
@@ -53,23 +53,19 @@ test( 'can walk through a proxy submission workflow and make a submission - with
     
     await walkThroughSubmissionFlow(t, true);
 
-}).timeouts({
-    pageLoadTimeout:    60000,
-    pageRequestTimeout: 60000,
-    ajaxRequestTimeout: 60000,
 }).disablePageCaching;
 
 test('can walk through a proxy submission workflow and make a submission - without pass account', async t => {
 
     // use role
-    await t.useRole(commonTest.userNih);
+    await t.useRole(userNih);
 
     // Go to Submissions
-    const submissionsButton = Selector('.nav-link.ember-view', {timeout: 15000}).withExactText('Submissions');
+    const submissionsButton = Selector('.nav-link.ember-view', {timeout: TIMEOUT_LENGTH}).withExactText('Submissions');
     await t.expect(submissionsButton.exists).ok();
     await t.click(submissionsButton);
 
-    await t.expect(commonTest.currLocation()).eql('https://pass.local/app/submissions');
+    await t.expect(currLocation()).eql('https://pass.local/app/submissions');
 
     // Start new Submission
     const startNewSubmissionButton = Selector('.ember-view.btn.btn-primary.btn-small.pull-right').withAttribute('href', '/app/submissions/new');
@@ -77,7 +73,7 @@ test('can walk through a proxy submission workflow and make a submission - witho
     await t.click(startNewSubmissionButton);
 
     // Select Proxy Submission button
-    await t.expect(commonTest.currLocation()).eql('https://pass.local/app/submissions/new/basics');
+    await t.expect(currLocation()).eql('https://pass.local/app/submissions/new/basics');
     const proxyRadioButton = Selector('input').withAttribute('data-test-proxy-radio-button');
     await t.expect(proxyRadioButton.exists).ok();
     await t.click(proxyRadioButton);
@@ -98,10 +94,6 @@ test('can walk through a proxy submission workflow and make a submission - witho
 
     await walkThroughSubmissionFlow(t, false);
 
-}).timeouts({
-    pageLoadTimeout:    60000,
-    pageRequestTimeout: 60000,
-    ajaxRequestTimeout: 60000,
 }).disablePageCaching;
 
 // t should be the test's promise, hasAccount should be a Bool
@@ -111,7 +103,7 @@ async function walkThroughSubmissionFlow(t, hasAccount){
     const doiInput = Selector('#doi');
     await t.expect(doiInput().exists).ok();
     await t.typeText(doiInput, '10.1039/c7an01256j', { paste: true });
-    const toastMessage = Selector('.toast-message', {timeout: 60000}).withText("We've pre-populated information from the DOI provided!");
+    const toastMessage = Selector('.toast-message', {timeout: TIMEOUT_LENGTH}).withText("We've pre-populated information from the DOI provided!");
     await t.expect(toastMessage.exists).ok();
 
     // Check that the title and journal values have been filled in
@@ -135,7 +127,7 @@ async function walkThroughSubmissionFlow(t, hasAccount){
     await t.expect(goToGrantsButton.exists).ok();
     await t.click(goToGrantsButton);
     
-    await t.expect(commonTest.currLocation()).eql('https://pass.local/app/submissions/new/grants');
+    await t.expect(currLocation()).eql('https://pass.local/app/submissions/new/grants');
 
     if (hasAccount){
         // Select a Grant
@@ -158,13 +150,13 @@ async function walkThroughSubmissionFlow(t, hasAccount){
     await t.expect(goToPoliciesButton.exists).ok();
     await t.click(goToPoliciesButton);
 
-    await t.expect(commonTest.currLocation()).eql('https://pass.local/app/submissions/new/policies');
+    await t.expect(currLocation()).eql('https://pass.local/app/submissions/new/policies');
     
     // Nothing to select here, move to Repositories page
     const goToRepositoriesButton = Selector('button').withAttribute('data-test-workflow-policies-next');
     await t.expect(goToRepositoriesButton.exists).ok();
     await t.click(goToRepositoriesButton);
-    await t.expect(commonTest.currLocation()).eql('https://pass.local/app/submissions/new/repositories');
+    await t.expect(currLocation()).eql('https://pass.local/app/submissions/new/repositories');
 
     // Check Required Repositories
     const requiredRepositories = Selector('ul')
@@ -176,7 +168,7 @@ async function walkThroughSubmissionFlow(t, hasAccount){
     await t.expect(goToMetadataButton.exists).ok();
     await t.click(goToMetadataButton);
 
-    await t.expect(commonTest.currLocation()).eql('https://pass.local/app/submissions/new/metadata');
+    await t.expect(currLocation()).eql('https://pass.local/app/submissions/new/metadata');
 
     // Check Article Title
     const articleTitle = Selector('textarea').withAttribute('name', 'title');
@@ -193,7 +185,7 @@ async function walkThroughSubmissionFlow(t, hasAccount){
     await t.expect(goToFilesButton.exists).ok();
     await t.click(goToFilesButton);
 
-    await t.expect(commonTest.currLocation()).eql('https://pass.local/app/submissions/new/files');
+    await t.expect(currLocation()).eql('https://pass.local/app/submissions/new/files');
 
     // Upload no file here
     const goToReviewButton = Selector('button').withAttribute('data-test-workflow-files-next');
@@ -207,7 +199,7 @@ async function walkThroughSubmissionFlow(t, hasAccount){
     await t.expect(nextPageButton.exists).ok();
     await t.click(nextPageButton);
 
-    await t.expect(commonTest.currLocation()).eql('https://pass.local/app/submissions/new/review');
+    await t.expect(currLocation()).eql('https://pass.local/app/submissions/new/review');
 
     // Go to Review
     // Review Title
@@ -241,7 +233,7 @@ async function walkThroughSubmissionFlow(t, hasAccount){
     await t.click(reviewSubmitButton);
 
     // Thank You Page
-    const thankYouHeading = Selector('h1').withExactText('Thank you!');
+    const thankYouHeading = Selector('h1', {timeout: TIMEOUT_LENGTH}).withExactText('Thank you!');
     await t.expect(thankYouHeading.exists).ok();
 
     // Click to submittion detail for validation

--- a/tests/proxySubmissionTests.js
+++ b/tests/proxySubmissionTests.js
@@ -1,0 +1,221 @@
+import { Selector } from 'testcafe';
+const commonTest = require("./commonTest");
+
+fixture `Acceptance Testing`
+    .page`https://pass.local`;
+
+test( 'Test prepping proxy submission', async t => {
+
+    // use role
+    await t.useRole(commonTest.userNih);
+
+    // Go to Submissions
+    const submissionsButton = Selector('.nav-link.ember-view').withExactText('Submissions');
+    await t.expect(submissionsButton.exists).ok();
+    await t.click(submissionsButton);
+
+    await t.expect(commonTest.currLocation()).eql('https://pass.local/app/submissions');
+
+    // Start new Submission
+    const startNewSubmissionButton = Selector('.ember-view.btn.btn-primary.btn-small.pull-right').withAttribute('href', '/app/submissions/new');
+    await t.expect(startNewSubmissionButton.exists).ok();
+    await t.click(startNewSubmissionButton);
+
+    // Select Proxy Submission button
+    await t.expect(commonTest.currLocation()).eql('https://pass.local/app/submissions/new/basics');
+    const proxyRadioButton = Selector('input').withAttribute('data-test-proxy-radio-button');
+    await t.expect(proxyRadioButton.exists).ok();
+    await t.click(proxyRadioButton);
+
+    const proxyInputBlock = Selector('#proxy-input-block');
+    await t.expect(proxyInputBlock.exists).ok();
+
+    // Input search term
+    const proxySearchInput = Selector('input').withAttribute('data-test-proxy-search-input');
+    await t.expect(proxySearchInput.exists).ok();
+    await t.typeText(proxySearchInput(), 'Staff');
+    await t.expect(proxySearchInput.value).eql('Staff');
+    const searchForUsers = Selector('#search-for-users');
+    await t.expect(searchForUsers.exists).ok();
+    await t.click(searchForUsers);
+
+    // Check search results
+    const searchResultsModal = Selector('.ember-modal-dialog');
+    await t.expect(searchResultsModal.exists).ok();
+    const userHasGrantsLink = Selector('a').withAttribute('data-test-found-proxy-user').withText('staffWithGrants@jhu.edu');
+    await t.expect(userHasGrantsLink.exists).ok();
+    // Select Submitter
+    await t.click(userHasGrantsLink);
+    await t.expect(searchResultsModal.exists).notOk();
+
+    const selectedUser = Selector('p').withText('Currently selected submitter:');
+    await t.expect(selectedUser.innerText).contains("Staff Hasgrants");
+    
+    await walkThroughSubmissionFlow(t, true);
+
+}).timeouts({
+    pageLoadTimeout:    60000,
+    pageRequestTimeout: 60000,
+    ajaxRequestTimeout: 60000,
+});;;
+
+// t should be the test's promise, hasAccount should be a Bool
+async function walkThroughSubmissionFlow(t, hasAccount){
+
+    // DOI
+    const doiInput = Selector('#doi');
+    await t.expect(doiInput().exists).ok();
+    await t.typeText(doiInput, '10.1039/c7an01256j', { paste: true });
+    const toastMessage = Selector('.toast-message', {timeout: 60000}).withText("We've pre-populated information from the DOI provided!");
+    await t.expect(toastMessage.exists).ok();
+
+    // Check that the title and journal values have been filled in
+    const titleName = Selector('#title');
+    await t.expect(titleName.value)
+        .eql('Quantitative profiling of carbonyl metabolites directly in crude biological extracts using chemoselective tagging and nanoESI-FTMS');
+    
+    const journalName = Selector('.form-control').withAttribute('data-test-journal-name-input');
+    await t.expect(journalName.value).eql('The Analyst');
+    
+    // Check that the title and journal values cannot be edited
+    await t.typeText(titleName, 'moo');
+    await t.expect(titleName.value)
+        .eql('Quantitative profiling of carbonyl metabolites directly in crude biological extracts using chemoselective tagging and nanoESI-FTMS');
+    
+    await t.typeText(journalName, 'moo');
+    await t.expect(journalName.value).eql('The Analyst');
+    
+    // Go to Grants
+    const goToGrantsButton = Selector('.btn.btn-primary.pull-right.next');
+    await t.expect(goToGrantsButton.exists).ok();
+    await t.click(goToGrantsButton);
+    
+    await t.expect(commonTest.currLocation()).eql('https://pass.local/app/submissions/new/grants');
+
+    if (hasAccount){
+        // Select a Grant
+        const hasGrantsGrant = Selector('#grants-selection-table a').withText('R124');
+        await t.expect(hasGrantsGrant.exists).ok();
+
+        await t.click(hasGrantsGrant().parent(0));
+        const submittedGrant = Selector('table').withAttribute('data-test-submission-funding-table')
+            .child('tbody').child('tr').child('td').child('a').withText('R124');
+        await t.expect(submittedGrant.exists).ok();
+    }
+    // TODO: add case for no account
+
+    // Go to Policies
+    const goToPoliciesButton = Selector('button').withAttribute('data-test-workflow-grants-next');
+    await t.expect(goToPoliciesButton.exists).ok();
+    await t.click(goToPoliciesButton);
+
+    await t.expect(commonTest.currLocation()).eql('https://pass.local/app/submissions/new/policies');
+    
+    // Nothing to select here, move to Repositories page
+    const goToRepositoriesButton = Selector('button').withAttribute('data-test-workflow-policies-next');
+    await t.expect(goToRepositoriesButton.exists).ok();
+    await t.click(goToRepositoriesButton);
+    await t.expect(commonTest.currLocation()).eql('https://pass.local/app/submissions/new/repositories');
+
+    // Check Required Repositories
+    const requiredRepositories = Selector('ul')
+        .withAttribute('data-test-workflow-repositories-required-list').child('li').withExactText('JScholarship');
+    await t.expect(requiredRepositories.exists).ok();
+
+    // Go to Metadata
+    const goToMetadataButton = Selector('button').withAttribute('data-test-workflow-repositories-next');
+    await t.expect(goToMetadataButton.exists).ok();
+    await t.click(goToMetadataButton);
+
+    await t.expect(commonTest.currLocation()).eql('https://pass.local/app/submissions/new/metadata');
+
+    // Check Article Title
+    const articleTitle = Selector('textarea').withAttribute('name', 'title');
+    await t.expect(articleTitle.value)
+        .eql('Quantitative profiling of carbonyl metabolites directly in crude biological extracts using chemoselective tagging and nanoESI-FTMS');
+
+    // Check Journal Title
+    const journalTitle = Selector('input').withAttribute('name', 'journal-title');
+    await t.expect(journalTitle.value)
+        .eql('The Analyst');
+    
+    // Go to Files
+    const goToFilesButton = Selector('.alpaca-form-button-Next');
+    await t.expect(goToFilesButton.exists).ok();
+    await t.click(goToFilesButton);
+
+    await t.expect(commonTest.currLocation()).eql('https://pass.local/app/submissions/new/files');
+
+    // Upload no file here
+    const goToReviewButton = Selector('button').withAttribute('data-test-workflow-files-next');
+    await t.expect(goToReviewButton.exists).ok();
+    await t.click(goToReviewButton);
+
+    const noManuscriptAlert = Selector('#swal2-title').withExactText('No manuscript present');
+    await t.expect(noManuscriptAlert.exists).ok();
+
+    const nextPageButton = Selector('.swal2-confirm').withExactText('OK');
+    await t.expect(nextPageButton.exists).ok();
+    await t.click(nextPageButton);
+
+    await t.expect(commonTest.currLocation()).eql('https://pass.local/app/submissions/new/review');
+
+    // Go to Review
+    // Review Title
+    const reviewTitle = Selector('.mb-1').withAttribute('data-test-workflow-review-title');
+    await t.expect(reviewTitle.innerText)
+        .eql('Quantitative profiling of carbonyl metabolites directly in crude biological extracts using chemoselective tagging and nanoESI-FTMS');
+    
+    // Review DOI
+    const reviewDoi = Selector('.mb-1').withAttribute('data-test-workflow-review-doi');
+    await t.expect(reviewDoi.innerText).eql('10.1039/c7an01256j');
+
+    // Rf grants are present, review here
+    if (hasAccount){
+        const reviewGrants = Selector('ul').withAttribute('data-test-workflow-review-grant-list').child('li').withText('R124');
+        await t.expect(reviewGrants.innerText).contains('R124');
+    }
+
+    // Review that this is a proxy submission
+    const submitterComment = Selector('p').withAttribute('data-test-workflow-review-submitter').withText('This submission is prepared on behalf of');
+    await t.expect(submitterComment.exists).ok();
+    if (hasAccount){
+        await t.expect(submitterComment.innerText).contains('Staff Hasgrants');
+    }
+    else{
+        await t.expect(submitterComment.innerText).contains('Staff Hasnogrants');
+    }
+
+    // Submit
+    const reviewSubmitButton = Selector('button').withAttribute('data-test-workflow-review-submit');
+    await t.expect(reviewSubmitButton.innerText).eql('Request approval');
+    await t.click(reviewSubmitButton);
+
+    // Thank You Page
+    const thankYouHeading = Selector('h1').withExactText('Thank you!');
+    await t.expect(thankYouHeading.exists).ok();
+
+    // Click to submittion detail for validation
+    const linkToSubmission = Selector('a').withExactText('here');
+    await t.expect(linkToSubmission.exists).ok();
+    await t.click(linkToSubmission);
+
+    // Submission heading
+    const submittedHeading = Selector('h5')
+        .withExactText('Quantitative profiling of carbonyl metabolites directly in crude biological extracts using chemoselective tagging and nanoESI-FTMS');
+    await t.expect(submittedHeading.exists).ok();
+
+    // Submission DOI
+    const submittedDoi = Selector('p').withExactText('DOI: 10.1039/c7an01256j');
+    await t.expect(submittedDoi.exists).ok();
+
+    // Submission Status
+    const submissionStatus = Selector('span').withAttribute('tooltip', 'This submission has been prepared on behalf of the designated submitter and is awaiting approval before being submitted.');
+    await t.expect(submissionStatus.exists).ok();
+
+    // Grant status
+    if (hasAccount){
+        const submissionGrants = Selector('li').withText('R124');
+        await t.expect(submissionGrants.exists).ok();
+    }
+}


### PR DESCRIPTION
Add acceptance tests for proxy submissions on behalf of submitter with and without a PASS account, rework the previous tests to split across multiple files for convenience.