### PR TITLE
Workaround test failures with images built in production mode

### DIFF
--- a/tests/baseCaseTests.js
+++ b/tests/baseCaseTests.js
@@ -1,11 +1,11 @@
 import { fixture, Selector, test } from 'testcafe';
-import { userNih, currLocation, TIMEOUT_LENGTH } from './commonTest';
+import { currLocation, TIMEOUT_LENGTH, login } from './commonTest';
 
 fixture`Acceptance Testing`.page`https://pass.local`;
 
 test('can walk through an nih submission workflow and make a submission - base case', async (t) => {
   // Log in
-  await t.useRole(userNih);
+  login('nih-user');
 
   // Go to Submissions
   const submissionsButton = Selector('.nav-link.ember-view').withText(

--- a/tests/commonTest.js
+++ b/tests/commonTest.js
@@ -1,50 +1,25 @@
-import { Selector, Role, ClientFunction } from 'testcafe';
+import { Selector, ClientFunction, t } from 'testcafe';
 
 const LOGIN_URL = 'https://pass.local/login/saml';
 
-export const userNih = Role(
-  LOGIN_URL,
-  async (t) => {
-    await t
-      .typeText(Selector('#username'), 'nih-user')
-      .typeText(Selector('#password'), 'moo')
-      .click(Selector('.form-element.form-button'));
-  },
-  { preserveUrl: true }
-);
+export const USER = {
+  NIH_USER: 'nih-user',
+  ADMIN_SUBMITTER: 'admin-submitter',
+};
 
-export const userIncompleteNih = Role(
-  LOGIN_URL,
-  async (t) => {
-    await t
-      .typeText(Selector('#username'), 'incomplete-nih-user')
-      .typeText(Selector('#password'), 'moo')
-      .click(Selector('.form-element.form-button'));
-  },
-  { preserveUrl: true }
-);
+export async function login(usr) {
+  return await t
+    .navigateTo(LOGIN_URL)
+    .typeText('#username', usr)
+    .typeText('#password', 'moo')
+    .click('.form-element.form-button');
+}
 
-export const userStaff1 = Role(
-  LOGIN_URL,
-  async (t) => {
-    await t
-      .typeText(Selector('#username'), 'staff1')
-      .typeText(Selector('#password'), 'moo')
-      .click(Selector('.form-element.form-button'));
-  },
-  { preserveUrl: true }
-);
-
-export const userAdminSubmitter = Role(
-  LOGIN_URL,
-  async (t) => {
-    await t
-      .typeText(Selector('#username'), 'admin-submitter')
-      .typeText(Selector('#password'), 'moo')
-      .click(Selector('.form-element.form-button'));
-  },
-  { preserveUrl: true }
-);
+export async function logout() {
+  return await t
+    .click('#user-menu-name') // Open the app menu to make logout btn visible
+    .click(Selector('#user-menu a').withText('Logout'));
+}
 
 export const currLocation = ClientFunction(() => window.location.href);
 

--- a/tests/proxySubmissionTests.js
+++ b/tests/proxySubmissionTests.js
@@ -1,11 +1,12 @@
 import { fixture, Selector, test } from 'testcafe';
-import { userAdminSubmitter, currLocation, TIMEOUT_LENGTH } from './commonTest';
+import { currLocation, TIMEOUT_LENGTH, login, logout } from './commonTest';
 
-fixture`Acceptance Testing`.page`https://pass.local`;
+fixture`Acceptance Testing`.page`https://pass.local`.afterEach(logout);
 
 test('can walk through a proxy submission workflow and make a submission - with pass account', async (t) => {
   // use role
-  await t.useRole(userAdminSubmitter);
+  // await t.useRole(userAdminSubmitter);
+  login('admin-submitter');
 
   // Go to Submissions
   const submissionsButton = Selector('.nav-link.ember-view').withText(
@@ -66,7 +67,8 @@ test('can walk through a proxy submission workflow and make a submission - with 
 
 test('can walk through a proxy submission workflow and make a submission - without pass account', async (t) => {
   // use role
-  await t.useRole(userAdminSubmitter);
+  // await t.useRole(userAdminSubmitter);
+  login('admin-submitter');
 
   // Go to Submissions
   const submissionsButton = Selector('.nav-link.ember-view', {


### PR DESCRIPTION
Fixes https://github.com/eclipse-pass/main/issues/849

Failures were only apparent specifically when `pass-ui` was built in production mode

## Changes

* Manually handle login/logout, instead of using Testcafe's [Roles mechanism](https://testcafe.io/documentation/402845/guides/intermediate-guides/authentication)

## Testing
Automations won't validate these changes, as they will currently run against SNAPSHOT/dev images, which worked previously anyway. Needs to be tested manually to verify:

* `pass-docker`: Checkout `1.2.0` tag, spin up the docker compose environment
* `pass-acceptance-testing`: on this branch, run `yarn && yarn test`

You can also repeat against pass-docker @main to run against `1.3.0-SNAPSHOT` images
