### PR TITLE
Print docker image info

### DIFF
--- a/.github/actions/acceptance-test/action.yml
+++ b/.github/actions/acceptance-test/action.yml
@@ -38,10 +38,15 @@ runs:
       working-directory: pass-docker
       run: docker compose -f docker-compose.yml -f eclipse-pass.local.yml up -d --no-build --quiet-pull --pull ${{ inputs.pullimages }}
 
+    # Show both views to see which images are in use by docker compose but with extra info like time created from docker
     - name: Print Docker images
       shell: bash
       working-directory: pass-docker
-      run: docker images
+      run: |
+        echo "##############"
+        docker images
+        echo "##############"
+        docker compose images
 
     - name: Run acceptance tests
       shell: bash

--- a/.github/actions/acceptance-test/action.yml
+++ b/.github/actions/acceptance-test/action.yml
@@ -38,6 +38,11 @@ runs:
       working-directory: pass-docker
       run: docker compose -f docker-compose.yml -f eclipse-pass.local.yml up -d --no-build --quiet-pull --pull ${{ inputs.pullimages }}
 
+    - name: Print Docker images
+      shell: bash
+      working-directory: pass-docker
+      run: docker images
+
     - name: Run acceptance tests
       shell: bash
       working-directory: pass-acceptance-testing


### PR DESCRIPTION
Adds some extra info aimed at other repos reusing this action. The idea is that printing this info will let someone reviewing the automation logs see which images participated in the acceptance tests, since other repos using this action will want to build newer images for testing