### PR TITLE
Update test gh workflow for complete release workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,11 +5,6 @@ on:
   pull_request:
     branches:
       - 'main'
-  push:
-    branches:
-      - 'main'
-    tags-ignore:
-      - '*'
 
 env:
   TIMEOUT_LENGTH: 120000


### PR DESCRIPTION
Needed for complete workflow fixes PR: https://github.com/eclipse-pass/main/pull/983

Removed push trigger all together for the test workflow.  Did not add trigger for PR merge because it running tests after a PR is merged is not needed.  Tests run when appropriate PRs are opened.