### PR TITLE
Add Ref input to tests workflow

### DIFF
--- a/.github/actions/acceptance-test/action.yml
+++ b/.github/actions/acceptance-test/action.yml
@@ -9,6 +9,9 @@ inputs:
   pullimages:
     description: 'Image pull policy (always|missing|never) [default: always]'
     default: 'always'
+  test-ref:
+    description: 'Ref (tag/branch/SHA)'
+    default: 'main'
 
 runs:
   using: composite
@@ -22,12 +25,14 @@ runs:
       with:
         repository: eclipse-pass/pass-docker
         path: pass-docker
+        ref: ${{ inputs.test-ref }}
 
     - name: Checkout pass-acceptance-testing
       uses: actions/checkout@v3
       with:
         repository: eclipse-pass/pass-acceptance-testing
         path: pass-acceptance-testing
+        ref: ${{ inputs.test-ref }}
 
     - name: Run pass-docker
       shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ on:
     branches:
       - 'main'
 
-run-name: Run tests::Ref=${{ inputs.test-ref }}
+run-name: Run acceptance tests::Ref=${{ inputs.test-ref }}
 
 env:
   TIMEOUT_LENGTH: 120000

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,8 @@ on:
     branches:
       - 'main'
 
+run-name: Run tests::Ref=${{ inputs.test-ref }}
+
 env:
   TIMEOUT_LENGTH: 120000
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ on:
     branches:
       - 'main'
 
-run-name: Run acceptance tests::Ref=${{ inputs.test-ref }}
+run-name: Run acceptance tests::Ref=${{ github.event_name == 'pull_request' && 'PR' || inputs.test-ref }}
 
 env:
   TIMEOUT_LENGTH: 120000
@@ -26,4 +26,4 @@ jobs:
         uses: ./.github/actions/acceptance-test
         with:
           timeouts: $TIMEOUT_LENGTH
-          test-ref: ${{ inputs.test-ref }}
+          test-ref: ${{ github.event_name == 'pull_request' && '' || inputs.test-ref }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,10 @@ name: test
 
 on:
   workflow_dispatch:
+    inputs:
+      test-ref:
+        description: 'Ref (tag/branch/SHA)'
+        default: 'main'
   pull_request:
     branches:
       - 'main'
@@ -20,3 +24,4 @@ jobs:
         uses: ./.github/actions/acceptance-test
         with:
           timeouts: $TIMEOUT_LENGTH
+          test-ref: ${{ inputs.test-ref }}


### PR DESCRIPTION
So that we can run the acceptance tests for a given version of PASS.  The Ref input is used to checkout the pass-acceptance-testing and pass-docker repos using it as ref param on the checkout action.