### PR TITLE
Verify DOI manuscripts on Files page

### DIFF
--- a/tests/baseCaseTests.js
+++ b/tests/baseCaseTests.js
@@ -68,6 +68,9 @@ test('can walk through an nih submission workflow and make a submission - base c
 
   await submissionMetadataPage.clickNextToFiles();
 
+  await submissionFilesPage.verifyOAManuscriptUrl(
+    'https://europepmc.org/articles/pmc6759371?pdf=render'
+  );
   await submissionFilesPage.uploadFile('my-submission.pdf');
   await submissionFilesPage.clickNextToReview();
 

--- a/tests/journalTests.js
+++ b/tests/journalTests.js
@@ -68,6 +68,7 @@ test('can walk through an submission workflow and make a submission with journal
 
   await submissionMetadataPage.clickNextToFiles();
 
+  await submissionFilesPage.verifyOAManuscriptsNotExists();
   await submissionFilesPage.uploadFile('my-submission.pdf');
   await submissionFilesPage.clickNextToReview();
 

--- a/tests/noJournalTests.js
+++ b/tests/noJournalTests.js
@@ -63,6 +63,7 @@ test('can walk through a submission workflow and make a submission - without sel
   await submissionMetadataPage.inputAuthor('PASS_E2E_TEST_AUTHOR');
   await submissionMetadataPage.clickNextToFiles();
 
+  await submissionFilesPage.verifyOAManuscriptsNotExists();
   await submissionFilesPage.uploadFile('my-submission.pdf');
   await submissionFilesPage.clickNextToReview();
 

--- a/tests/page_model/SubmissionFiles.js
+++ b/tests/page_model/SubmissionFiles.js
@@ -65,6 +65,18 @@ class SubmissionFiles {
       .expect(currLocation())
       .eql(`${PASS_BASE_URL}/app/submissions/new/review`);
   }
+
+  async verifyOAManuscriptUrl(expectedUrl) {
+    const manuscriptUrl = Selector('span.pl-2').withText(expectedUrl);
+    await t.expect(manuscriptUrl.innerText).contains(expectedUrl);
+  }
+
+  async verifyOAManuscriptsNotExists() {
+    const oaManuFound = Selector('p.text-muted').withText(
+      'We found the following OA copies of your manuscript/article.'
+    );
+    await t.expect(oaManuFound.exists).notOk();
+  }
 }
 
 export default new SubmissionFiles();

--- a/tests/proxySubmissionTests.js
+++ b/tests/proxySubmissionTests.js
@@ -156,6 +156,9 @@ async function walkThroughSubmissionFlow(t, hasAccount) {
   await submissionMetadataPage.verifyJournalTitle('The Analyst');
   await submissionMetadataPage.clickNextToFiles();
 
+  await submissionFilesPage.verifyOAManuscriptUrl(
+    'https://europepmc.org/articles/pmc6759371?pdf=render'
+  );
   // Upload no file here
   await submissionFilesPage.clickNextToReviewNoFiles();
 


### PR DESCRIPTION
The acceptance tests now verify the DOI manuscripts URLs on the Files page, and they verify when they should not be there as well.