### PR TITLE
Deployment test fix

### DIFF
--- a/tests/page_model/SubmissionDetails.js
+++ b/tests/page_model/SubmissionDetails.js
@@ -64,7 +64,7 @@ class SubmissionDetails {
 
   async verifyJScholarshipManuscriptIdExists() {
     const manuscriptIdDiv = Selector('div').withText(
-      /JScholarship[\s\S]*Manuscript ID[\s\S]*http[\s\S]*items[\s\S]*/
+      /JScholarship[\s\S]*Manuscript ID[\s\S]*http[\s\S]*(items|handle)[\s\S]*/
     );
     await t.expect(manuscriptIdDiv.exists).ok();
   }


### PR DESCRIPTION
This PR changes the deployment test verification to support `items` or `handle` in the deposit link.

Related to https://github.com/eclipse-pass/main/issues/1127