### PR TITLE
Make journal name validation less strict

### DIFF
--- a/tests/page_model/SubmissionBasic.js
+++ b/tests/page_model/SubmissionBasic.js
@@ -63,7 +63,10 @@ class SubmissionBasic {
   }
 
   async validateJournal(expectedJournal) {
-    await t.expect(this.journalName.value).eql(expectedJournal);
+    const actualJournalName = await this.journalName.value;
+    await t
+      .expect(actualJournalName.toLowerCase())
+      .contains(expectedJournal.toLowerCase());
   }
 
   async validateJournalIsEmpty() {

--- a/tests/page_model/SubmissionMetadata.js
+++ b/tests/page_model/SubmissionMetadata.js
@@ -25,8 +25,12 @@ class SubmissionMetadata {
   }
 
   async verifyJournalTitle(expectedJournalTitle) {
-    const journalTitle = Selector('div[data-name=journal-title] input');
-    await t.expect(journalTitle.value).eql(expectedJournalTitle);
+    const actualJournalTitle = await Selector(
+      'div[data-name=journal-title] input'
+    ).value;
+    await t
+      .expect(actualJournalTitle.toLowerCase())
+      .contains(expectedJournalTitle.toLowerCase());
   }
 
   async inputAuthor(authorName) {


### PR DESCRIPTION
So that minor differences in journalName values environments don't cause failures.