### PR TITLE
Fix testcafe and chrome 142.x issue

### DIFF
--- a/.github/actions/acceptance-test/action.yml
+++ b/.github/actions/acceptance-test/action.yml
@@ -55,7 +55,8 @@ runs:
       run: |
         yarn install --frozen-lockfile
         npx testcafe \
-          'chrome:headless --ignore-certificate-errors --allow-insecure-localhost' \
+          'chrome:headless --ignore-certificate-errors --allow-insecure-localhost \
+          --disable-features=LocalNetworkAccessChecks' \
           --hostname localhost \
           --base-url http://localhost:8080 \
           tests/*Tests.js \

--- a/.github/actions/acceptance-test/action.yml
+++ b/.github/actions/acceptance-test/action.yml
@@ -55,8 +55,7 @@ runs:
       run: |
         yarn install --frozen-lockfile
         npx testcafe \
-          'chrome:headless --ignore-certificate-errors --allow-insecure-localhost \
-          --disable-features=LocalNetworkAccessChecks' \
+          'chrome:headless --ignore-certificate-errors --allow-insecure-localhost --disable-features=LocalNetworkAccessChecks' \
           --hostname localhost \
           --base-url http://localhost:8080 \
           tests/*Tests.js \


### PR DESCRIPTION
Testcafe is hanging with latest chrome 142.x version. Found this issue and tried workaround, it works for our CI. https://github.com/DevExpress/testcafe/issues/8446