### PR TITLE
Change github workflow actions to use immutable versions

### DIFF
--- a/.github/actions/acceptance-test/action.yml
+++ b/.github/actions/acceptance-test/action.yml
@@ -21,14 +21,14 @@ runs:
       shell: bash
 
     - name: Checkout pass-docker
-      uses: actions/checkout@v3
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         repository: eclipse-pass/pass-docker
         path: pass-docker
         ref: ${{ inputs.test-ref }}
 
     - name: Checkout pass-acceptance-testing
-      uses: actions/checkout@v3
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         repository: eclipse-pass/pass-acceptance-testing
         path: pass-acceptance-testing

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Config git user
         run: |
@@ -24,7 +24,7 @@ jobs:
           git config user.email "${{ github.actor }}@users.noreply.github.com"
       
       - name: Setup Node & Yarn
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: 24
           cache: 'yarn'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,10 +20,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout pass-acceptance-testing
-        uses: actions/checkout@v3
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Use Node.js 24
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
             node-version: '24'
             cache: 'yarn'


### PR DESCRIPTION
As part of security best practices update.

Pins all third-party GitHub Actions to immutable commit SHAs instead of mutable version tags. This prevents supply chain attacks where a tag (e.g. v4) could be silently moved to point to different — potentially malicious — code. The version tag is retained as a comment for readability.

Actions updated:

actions/checkout → v6.0.2
actions/setup-java → v5.2.0
actions/setup-python → v4.9.1
actions/setup-node → v5.0.0
docker/login-action → v3.7.0
pnpm/action-setup → v4.4.0